### PR TITLE
[Fix]商品一覧と詳細の価格表示、新規登録後の遷移先

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -11,7 +11,7 @@ class Admin::ItemsController < ApplicationController
   def create
     item = Item.new(item_params)
     item.save
-    redirect_to admin_items_path
+    redirect_to admin_item_path(item)
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,9 +5,16 @@ class Item < ApplicationRecord
   belongs_to :genre
   has_one_attached :image
   
-
   def with_tax_price
     (price * 1.1).floor
+  end
+  
+  def cal_price
+    (price_no_tax*1.1).floor.to_s(:delimited)
+  end
+  
+  def adj_price
+    price_no_tax.to_s(:delimited)
   end
   
   def get_image(width, height)

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -25,7 +25,7 @@
             <%= item.name %>
           <% end %>
           </td>
-        <td><%= item.price_no_tax.to_s(:delimited) %></td>
+        <td><%= item.adj_price %></td>
         <td><%= item.genre.name %></td>
         <td>
           <% if item.sales_status %>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -21,8 +21,8 @@
           </tr>
           <tr>
           <th>税込価格<br>(税抜価格)</th>
-          <td><%= (1.1*(@item.price_no_tax)).round.to_s(:delimited) %>
-              (<%= @item.price_no_tax.to_s(:delimited) %>)円
+          <td><%= @item.cal_price %>
+              (<%= @item.adj_price %>)円
           </td>
           </tr>
           <tr>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 2022_02_20_045906) do
     t.string "item_image", null: false
     t.boolean "sales_status", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6 , null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,3 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-


### PR DESCRIPTION
# 変更点
- 管理者側での商品一覧と商品詳細画面の価格表示を、メソッドを用いて表示するようにした。
- 管理者側で商品を新規登録したときに、詳細画面へ遷移するように修正した。